### PR TITLE
Fix docs and list formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command-line interface with customizable options:
   - `--width`: Set body wrap width
   - `--headline-width`: Advisory headline width
-  - `--no-ansi`: Strip ANSI color codes
 - Nix package definition for easy installation
 - Basic test suite and project structure
 - MIT/Apache-2.0 dual licensing

--- a/PRD.md
+++ b/PRD.md
@@ -53,7 +53,6 @@ Provide a **stream-oriented** command-line filter (`rule72`) that reads an unfor
    - Flags:
      * `-w`, `--width` <N>: set wrap width (default 72)
      * `--headline-width` <N>: advisory width for headline (default 50; no hard split)
-     * `--no-ansi`: strip ANSI color codes before measuring width
      * `--debug-svg` <path>: output SVG visualization of parsing/classification
 8. **Exit Codes**
    - `0` success; formatted text on stdout

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ CLI flags:
 ```
   -w, --width <N>           set body wrap width (default 72)
       --headline-width <N>  advisory headline width (default 50)
-      --no-ansi             strip colour codes before measuring width
       --debug-svg <PATH>    generate SVG visualization of parsing/classification
       --debug-trace         output detailed trace of parsing pipeline
 ```

--- a/rule72/src/classifier.rs
+++ b/rule72/src/classifier.rs
@@ -115,7 +115,6 @@ mod tests {
         let opts = Options {
             width: 72,
             headline_width: 50,
-            strip_ansi: false,
             debug_svg: None,
             debug_trace: false,
         };

--- a/rule72/src/lexer.rs
+++ b/rule72/src/lexer.rs
@@ -98,7 +98,6 @@ mod tests {
         let opts = Options {
             width: 72,
             headline_width: 50,
-            strip_ansi: false,
             debug_svg: None,
             debug_trace: false,
         };

--- a/rule72/src/lib.rs
+++ b/rule72/src/lib.rs
@@ -70,7 +70,6 @@ mod tests {
         let opts = Options {
             width: 72,
             headline_width: 50,
-            strip_ansi: false,
             debug_svg: None,
             debug_trace: false,
         };

--- a/rule72/src/main.rs
+++ b/rule72/src/main.rs
@@ -32,12 +32,6 @@ fn main() -> Result<()> {
                 .default_value("50"),
         )
         .arg(
-            Arg::new("no-ansi")
-                .long("no-ansi")
-                .help("Strip ANSI color codes before measuring width")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
             Arg::new("debug-svg")
                 .long("debug-svg")
                 .value_name("PATH")
@@ -56,14 +50,12 @@ fn main() -> Result<()> {
         .get_one::<String>("headline-width")
         .unwrap()
         .parse()?;
-    let strip_ansi = matches.get_flag("no-ansi");
     let debug_svg = matches.get_one::<String>("debug-svg").cloned();
     let debug_trace = matches.get_flag("debug-trace");
 
     let opts = Options {
         width,
         headline_width,
-        strip_ansi,
         debug_svg,
         debug_trace,
     };

--- a/rule72/src/pretty_printer.rs
+++ b/rule72/src/pretty_printer.rs
@@ -77,6 +77,7 @@ pub fn pretty_print_list(list: &ListNode, opts: &Options, _depth: usize) -> Vec<
 
     for item in &list.items {
         let bullet_prefix = extract_bullet_prefix(&item.bullet_line.text);
+        let bullet_width = display_width(bullet_prefix);
         let text_start = item.bullet_line.text[bullet_prefix.len()..].trim_start();
 
         // Combine bullet line and continuation
@@ -94,17 +95,13 @@ pub fn pretty_print_list(list: &ListNode, opts: &Options, _depth: usize) -> Vec<
                 .iter()
                 .any(|l| display_width(&l.text) > opts.width)
         {
-            let wrapped = wrap_text(&full_text, opts.width - bullet_prefix.len());
+            let wrapped = wrap_text(&full_text, opts.width - bullet_width);
             for (i, line) in wrapped.iter().enumerate() {
                 if i == 0 {
                     output.push(format!("{}{}", bullet_prefix, line));
                 } else {
-                    output.push(format!(
-                        "{:width$}{}",
-                        "",
-                        line,
-                        width = bullet_prefix.len()
-                    ));
+                    let padding = " ".repeat(bullet_width);
+                    output.push(format!("{}{}", padding, line));
                 }
             }
         } else {
@@ -154,7 +151,6 @@ mod tests {
         let opts = Options {
             width: 50,
             headline_width: 50,
-            strip_ansi: false,
             debug_svg: None,
             debug_trace: false,
         };

--- a/rule72/src/tree_builder.rs
+++ b/rule72/src/tree_builder.rs
@@ -237,7 +237,6 @@ mod tests {
         let opts = Options {
             width: 72,
             headline_width: 50,
-            strip_ansi: false,
             debug_svg: None,
             debug_trace: false,
         };

--- a/rule72/src/types.rs
+++ b/rule72/src/types.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 pub struct Options {
     pub width: usize,
     pub headline_width: usize,
-    pub strip_ansi: bool,
     pub debug_svg: Option<String>,
     pub debug_trace: bool,
 }
@@ -22,7 +21,6 @@ impl Default for Options {
         Self {
             width: 72,
             headline_width: 50,
-            strip_ansi: false,
             debug_svg: None,
             debug_trace: false,
         }

--- a/rule72/src/utils.rs
+++ b/rule72/src/utils.rs
@@ -19,7 +19,7 @@ macro_rules! debug_trace {
 pub(crate) use debug_trace;
 
 /// Count leading whitespace characters (spaces and tabs) in a line.
-/// Tabs are counted as single characters for simplicity.
+/// Tabs are treated as four spaces when measuring indentation.
 pub fn count_indent(line: &str) -> usize {
     line.chars()
         .take_while(|&c| c == ' ' || c == '\t')


### PR DESCRIPTION
## Summary
- drop unused CLI flag `--no-ansi`
- correct tab handling comment
- align wrapped list items using display width

## Testing
- `nix-shell --run "just lint"`
- `nix-shell --run "just test"`

------
https://chatgpt.com/codex/tasks/task_e_687250aab080832ba66791d66c55aa9c