### PR TITLE
Align docs with repo

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -200,37 +200,23 @@ cat commit.txt | rule72 --debug-svg debug.svg
 - Lints: `clippy`, formatting via `rustfmt`
 
 ### Nix Environment (`shell.nix`)
-```nix
-{ pkgs ? import <nixpkgs> {} }:
-pkgs.mkShell {
-  buildInputs = [
-    pkgs.rustc pkgs.cargo pkgs.clippy pkgs.rustfmt
-    pkgs.pkg-config pkgs.openssl # future TLS crates if needed
-    pkgs.musl    # static linking target
-  ];
-  RUSTFLAGS = "-C target-feature=+crt-static";
-}
-```
-Invoke with `nix-shell --run <cmd>` as required by user rules.
+`Nix` provides a reproducible shell with the Rust toolchain and auxiliary
+development tools.  Packages such as `rustc`, `cargo`, `clippy`, `rustfmt` and
+the `just` command are pinned in `shell.nix`.  Invoke `nix-shell --run <cmd>` to
+execute any of the tasks below or plain Cargo commands.
 
 ### Task Automation (`Justfile`)
-```just
-# Build release binary (static)
-build:
-  nix-shell --run "cargo build --release --target x86_64-unknown-linux-musl"
+Routine commands are defined in a `Justfile` and executed via `just`:
 
-# Run unit + integration tests
-test:
-  nix-shell --run "cargo test --all"
+- **build** – compile the release binary
+- **test** – run unit and integration tests
+- **fmt** – format the source with `rustfmt`
+- **lint** – run `clippy` with warnings as errors
+- **reflow-data**/`compare-data` – verify message corpus formatting
+- **check-data-changes** – ensure regenerated corpus is clean
+- **nix-test** – confirm the Nix derivation works
 
-# Format source tree
-fmt:
-  nix-shell --run "cargo fmt --all"
-
-# Static analysis
-lint:
-  nix-shell --run "cargo clippy -- -D warnings"
-```
+Run `just --list` to see the full set of tasks.
 
 ### Directory Layout
 ```
@@ -244,10 +230,18 @@ rule72/
 ```
 
 ### CI Consideration
-- GitHub Actions job uses `nix` to enter shell and run `just build && just test`.
-- Produces `rule72` artifact uploaded as release.
+GitHub Actions defines multiple jobs:
+
+- **build** – compile the release binary via Nix
+- **lint** – run `clippy` with warnings as errors
+- **test** – execute unit tests
+- **reflow-data** and **compare-data** – verify formatting on the message corpus
+- **check-data-changes** – fail if reflowed output differs
+- **nix-test** – ensure the Nix derivation builds and the binary runs
+
+Artifacts include the compiled `rule72` binary.
 
 ---
 Additions above define how to build, test, and lint the Rust implementation via Nix and Just.
 
-*Author: TBD • Last updated: <!-- YYYY-MM-DD -->* 
+*Author: Mark Ruvald Pedersen • Last updated: 2025-07-10*

--- a/rule72/Cargo.lock
+++ b/rule72/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rule72"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/rule72/Cargo.toml
+++ b/rule72/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rule72"
-version = "0.1.0"
+version = "0.2.2"
 edition = "2021"
-authors = ["TBD"]
+authors = ["Mark Ruvald Pedersen"]
 license = "MIT OR Apache-2.0"
 description = "Git commit-message reflow CLI tool"
 


### PR DESCRIPTION
## Summary
- update `shell.nix` section in PRD for current packages
- document all `just` tasks
- describe full CI jobs and update metadata
- bump crate metadata to v0.2.2
- generalize Nix and automation sections

## Testing
- `nix-shell --run "just lint"`
- `nix-shell --run "just test"`


------
https://chatgpt.com/codex/tasks/task_e_687250e572f4832ba87b2d5a0e90cdc6