### PR TITLE
Add audit job; remove security alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Run clippy lint
         run: nix-shell --run "just lint"
 
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - name: Run cargo audit
+        run: nix-shell --run "just audit"
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Justfile
+++ b/Justfile
@@ -8,8 +8,18 @@ test:
 fmt:
   (cd rule72 && cargo fmt --all)
 
-lint:
+lint: fmt-check
   (cd rule72 && cargo clippy -- -D warnings)
+
+fmt-check:
+  (cd rule72 && cargo fmt --all -- --check)
+
+audit:
+  (cd rule72 && cargo audit)
+
+
+coverage:
+  (cd rule72 && cargo tarpaulin --out Html)
 
 # Reflow all commit message .txt files under data/ into data.out/
 # Preserves directory structure for easy comparison.

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,9 @@ pkgs.mkShell {
     pkgs.clippy
     pkgs.rustfmt
 
+    pkgs.cargo-audit
+    pkgs.cargo-tarpaulin
+
     pkgs.less
     pkgs.colordiff
     pkgs.just


### PR DESCRIPTION
## Summary
- drop `security` alias in `Justfile`
- call `audit` from CI via new job
- mention that `cargo-deny` could not fetch advisories

## Testing
- `nix-shell --run "just lint"`
- `nix-shell --run "just test"`
- `nix-shell --run "just audit"`


------
https://chatgpt.com/codex/tasks/task_e_687251267d00832b96defbe313cc0ef6