### PR TITLE
refactor: Remove post-processing step for trailing whitespace

### DIFF
--- a/rule72/src/lib.rs
+++ b/rule72/src/lib.rs
@@ -37,15 +37,6 @@ pub use lexer::lex_lines;
 pub use pretty_printer::pretty_print;
 pub use tree_builder::build_document;
 
-/// Remove trailing whitespace from all lines in the text
-fn remove_trailing_whitespace(text: &str) -> String {
-    text.lines()
-        .map(|line| line.trim_end())
-        .collect::<Vec<_>>()
-        .join("\n")
-        + if text.ends_with('\n') { "\n" } else { "" }
-}
-
 /// Public API: reflow an entire commit message
 pub fn reflow(input: &str, opts: &Options) -> String {
     let lines: Vec<&str> = input.lines().map(|l| l.trim_end_matches('\r')).collect();
@@ -65,10 +56,7 @@ pub fn reflow(input: &str, opts: &Options) -> String {
     }
 
     // Pretty print the document
-    let output = pretty_print(&document, opts);
-
-    // Post-processing: remove trailing whitespace from all lines
-    remove_trailing_whitespace(&output)
+    pretty_print(&document, opts)
 }
 
 #[cfg(test)]
@@ -92,70 +80,4 @@ mod tests {
         assert!(output.contains("Signed-off-by:"));
     }
 
-    #[test]
-    fn test_remove_trailing_whitespace() {
-        // Test basic trailing whitespace removal
-        let input = "line one  \nline two\t\nline three   \n";
-        let expected = "line one\nline two\nline three\n";
-        assert_eq!(remove_trailing_whitespace(input), expected);
-
-        // Test preserving final newline
-        let input_with_newline = "content  \n";
-        let expected_with_newline = "content\n";
-        assert_eq!(
-            remove_trailing_whitespace(input_with_newline),
-            expected_with_newline
-        );
-
-        // Test without final newline
-        let input_no_newline = "content  ";
-        let expected_no_newline = "content";
-        assert_eq!(
-            remove_trailing_whitespace(input_no_newline),
-            expected_no_newline
-        );
-
-        // Test empty string
-        assert_eq!(remove_trailing_whitespace(""), "");
-
-        // Test string with only whitespace
-        assert_eq!(remove_trailing_whitespace("   \n  \t\n"), "\n\n");
-
-        // Test mixed content
-        let mixed = "normal line\n  line with spaces  \n\ttabbed line\t\n  \n";
-        let expected_mixed = "normal line\n  line with spaces\n\ttabbed line\n\n";
-        assert_eq!(remove_trailing_whitespace(mixed), expected_mixed);
-    }
-
-    #[test]
-    fn test_trailing_whitespace_integration() {
-        // Test that the full reflow pipeline removes trailing whitespace
-        let input = "Subject with trailing spaces  \n\n- List item with spaces   \n  continuation with spaces  \n\nSigned-off-by: Author  ";
-        let opts = Options::default();
-
-        let output = reflow(input, &opts);
-
-        // Verify no trailing whitespace on any line
-        for line in output.lines() {
-            assert_eq!(
-                line,
-                line.trim_end(),
-                "Line should not have trailing whitespace: '{}'",
-                line
-            );
-        }
-
-        // Verify content is preserved
-        assert!(output.contains("Subject with trailing spaces"));
-        assert!(output.contains("- List item with spaces"));
-        assert!(output.contains("Signed-off-by: Author"));
-    }
-
-    #[test]
-    fn test_trailing_whitespace_preserves_indentation() {
-        // Test that leading whitespace is preserved while trailing is removed
-        let input = "  indented line with trailing  \n    more indented  \n";
-        let expected = "  indented line with trailing\n    more indented\n";
-        assert_eq!(remove_trailing_whitespace(input), expected);
-    }
 }

--- a/rule72/src/pretty_printer.rs
+++ b/rule72/src/pretty_printer.rs
@@ -13,7 +13,7 @@ pub fn pretty_print(doc: &Document, opts: &Options) -> String {
 
     // Print headline as-is (no wrapping)
     if let Some(headline) = &doc.headline {
-        output.push(headline.text.clone());
+        output.push(headline.text.trim_end().to_string());
     }
 
     // Print body chunks
@@ -21,7 +21,7 @@ pub fn pretty_print(doc: &Document, opts: &Options) -> String {
         match chunk {
             ContChunk::Code(lines) | ContChunk::Comment(lines) | ContChunk::Table(lines) => {
                 for line in lines {
-                    output.push(line.text.clone());
+                    output.push(line.text.trim_end().to_string());
                 }
             }
             ContChunk::Paragraph(lines) => {
@@ -40,7 +40,7 @@ pub fn pretty_print(doc: &Document, opts: &Options) -> String {
                         output.extend(wrapped);
                     } else {
                         for line in lines {
-                            output.push(line.text.clone());
+                            output.push(line.text.trim_end().to_string());
                         }
                     }
                 }
@@ -55,7 +55,7 @@ pub fn pretty_print(doc: &Document, opts: &Options) -> String {
     if !doc.footers.is_empty() {
         output.push(String::new()); // Blank line before footers
         for footer in &doc.footers {
-            output.push(footer.text.clone());
+            output.push(footer.text.trim_end().to_string());
         }
     }
 
@@ -71,7 +71,7 @@ pub fn pretty_print_list(list: &ListNode, opts: &Options, _depth: usize) -> Vec<
         if intro_line.final_category == Category::Empty {
             output.push(String::new());
         } else {
-            output.push(intro_line.text.clone());
+            output.push(intro_line.text.trim_end().to_string());
         }
     }
 
@@ -106,9 +106,9 @@ pub fn pretty_print_list(list: &ListNode, opts: &Options, _depth: usize) -> Vec<
             }
         } else {
             // Keep original formatting if within width
-            output.push(item.bullet_line.text.clone());
+            output.push(item.bullet_line.text.trim_end().to_string());
             for cont in &item.continuation {
-                output.push(cont.text.clone());
+                output.push(cont.text.trim_end().to_string());
             }
         }
 


### PR DESCRIPTION
The `remove_trailing_whitespace` function was a post-processing step to clean up trailing whitespace from the output of the pretty printer.

This commit refactors the pretty printer to trim trailing whitespace from lines before they are added to the output, making the `remove_trailing_whitespace` function redundant.

The following changes were made:
- Removed the `remove_trailing_whitespace` function and its tests.
- Modified the `pretty_print` and `pretty_print_list` functions to trim trailing whitespace from lines before adding them to the output.