### PR TITLE
Fix: Prevent division by zero in lexer

### DIFF
--- a/rule72/src/debug.rs
+++ b/rule72/src/debug.rs
@@ -97,14 +97,12 @@ pub fn generate_debug_svg(doc: &Document, path: &str) {
 
     let mut svg = String::new();
     svg.push_str(&format!(
-        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{}" height="{}" viewBox="0 0 {} {}">"#,
-        svg_width, svg_height, svg_width, svg_height
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{svg_width}" height="{svg_height}" viewBox="0 0 {svg_width} {svg_height}">"#
     ));
 
     svg.push_str("\n<style>\n");
     svg.push_str(&format!(
-        "    text {{ font-family: monospace; font-size: {}px; }}\n",
-        font_size
+        "    text {{ font-family: monospace; font-size: {font_size}px; }}\n"
     ));
     svg.push_str("    .headline { fill: #2e3440; }\n");
     svg.push_str("    .comment { fill: #616e88; }\n");
@@ -134,8 +132,7 @@ pub fn generate_debug_svg(doc: &Document, path: &str) {
             let dots_count = if chunk_type == &"headline" { 50 } else { 72 };
             let dots = "·".repeat(dots_count);
             svg.push_str(&format!(
-                r#"<text x="{}" y="{}" class="ruler-dots">{}</text>"#,
-                margin, ruler_y, dots
+                r#"<text x="{margin}" y="{ruler_y}" class="ruler-dots">{dots}</text>"#
             ));
         }
         prev_chunk_type = chunk_type;
@@ -191,7 +188,7 @@ pub fn generate_debug_svg(doc: &Document, path: &str) {
         let prob_text = line
             .probabilities
             .iter()
-            .map(|(cat, prob)| format!("  {:?}: {:.2}", cat, prob))
+            .map(|(cat, prob)| format!("  {cat:?}: {prob:.2}"))
             .collect::<Vec<_>>()
             .join("\n");
 
@@ -257,8 +254,7 @@ Probabilities:
         let label_x = margin + max_width * char_width - 5; // Near right edge
         let label_y = chunk_y + chunk_height - 3; // Near bottom edge
         svg.push_str(&format!(
-            r#"<text x="{}" y="{}" class="chunk-label" text-anchor="end">{}</text>"#,
-            label_x, label_y, chunk_type
+            r#"<text x="{label_x}" y="{label_y}" class="chunk-label" text-anchor="end">{chunk_type}</text>"#
         ));
     }
 
@@ -267,9 +263,9 @@ Probabilities:
     // Write to file
     if let Ok(mut file) = File::create(path) {
         let _ = file.write_all(svg.as_bytes());
-        eprintln!("Debug SVG written to: {}", path);
+        eprintln!("Debug SVG written to: {path}");
     } else {
-        eprintln!("Failed to create SVG file: {}", path);
+        eprintln!("Failed to create SVG file: {path}");
     }
 }
 

--- a/rule72/src/lexer.rs
+++ b/rule72/src/lexer.rs
@@ -43,7 +43,7 @@ pub fn lex_lines(lines: &[&str], opts: &Options) -> Vec<CatLine> {
                 probabilities.insert(Category::List, 0.92);
                 probabilities.insert(Category::ProseGeneral, 0.08);
             } else if indent >= 4
-                || (trimmed.len() > 0
+                || (!trimmed.is_empty()
                     && count_special_chars(trimmed) as f32 / trimmed.len() as f32 > 0.3)
             {
                 probabilities.insert(Category::Code, 0.77);

--- a/rule72/src/lexer.rs
+++ b/rule72/src/lexer.rs
@@ -43,7 +43,8 @@ pub fn lex_lines(lines: &[&str], opts: &Options) -> Vec<CatLine> {
                 probabilities.insert(Category::List, 0.92);
                 probabilities.insert(Category::ProseGeneral, 0.08);
             } else if indent >= 4
-                || count_special_chars(trimmed) as f32 / trimmed.len() as f32 > 0.3
+                || (trimmed.len() > 0
+                    && count_special_chars(trimmed) as f32 / trimmed.len() as f32 > 0.3)
             {
                 probabilities.insert(Category::Code, 0.77);
                 probabilities.insert(Category::ProseGeneral, 0.23);

--- a/rule72/src/main.rs
+++ b/rule72/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
     io::stdin().read_to_string(&mut input)?;
 
     let output = reflow(&input, &opts);
-    print!("{}", output);
+    print!("{output}");
 
     Ok(())
 }

--- a/rule72/src/pretty_printer.rs
+++ b/rule72/src/pretty_printer.rs
@@ -89,7 +89,7 @@ pub fn pretty_print_list(list: &ListNode, opts: &Options, _depth: usize) -> Vec<
         }
 
         // Check if wrapping is needed
-        let first_line = format!("{}{}", bullet_prefix, text_start);
+        let first_line = format!("{bullet_prefix}{text_start}");
         if display_width(&first_line) > opts.width
             || item
                 .continuation
@@ -99,10 +99,10 @@ pub fn pretty_print_list(list: &ListNode, opts: &Options, _depth: usize) -> Vec<
             let wrapped = wrap_text(&full_text, opts.width - bullet_width);
             for (i, line) in wrapped.iter().enumerate() {
                 if i == 0 {
-                    output.push(format!("{}{}", bullet_prefix, line));
+                    output.push(format!("{bullet_prefix}{line}"));
                 } else {
                     let padding = " ".repeat(bullet_width);
-                    output.push(format!("{}{}", padding, line));
+                    output.push(format!("{padding}{line}"));
                 }
             }
         } else {

--- a/rule72/tests/cli.rs
+++ b/rule72/tests/cli.rs
@@ -24,6 +24,21 @@ fn test_width_arg() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn test_division_by_zero_cli() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("rule72")?;
+    let mut child = cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
+
+    let child_stdin = child.stdin.as_mut().unwrap();
+    child_stdin.write_all(b"Subject\n\n \n")?;
+
+    let output = child.wait_with_output()?;
+    assert!(output.status.success());
+
+    Ok(())
+}
+
+
+#[test]
 fn test_headline_width_arg() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("rule72")?;
     let mut child = cmd


### PR DESCRIPTION
A line containing only whitespace could cause a division by zero panic in the lexer. This was because the line would be trimmed to an empty string, and the code would then attempt to divide by the length of the string, which was zero.

This commit fixes the bug by adding a check to ensure that the length of the trimmed line is greater than zero before performing the division.